### PR TITLE
Add support for scala 2.12 and play 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
     - $HOME/.sbt/boot/
 
 jdk:
-- oraclejdk8
+- openjdk8
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,17 @@ cache:
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot/
 
-scala:
-- 2.11.7
-
 jdk:
 - oraclejdk8
+
+matrix:
+  include:
+  - scala: 2.11.12
+    env: PLAY_VERSION=2.5
+  - scala: 2.11.12
+    env: PLAY_VERSION=2.6
+  - scala: 2.12.8
+    env: PLAY_VERSION=2.6
 
 
 script:

--- a/build.sbt
+++ b/build.sbt
@@ -4,22 +4,42 @@ import uk.gov.hmrc.versioning.SbtGitVersioning
 
 val appName = "json-encryption"
 
-val dependencies = Seq(
-  "com.typesafe.play" %% "play-json" % "2.5.12" % "provided",
-  "uk.gov.hmrc"       %% "crypto"    % "5.1.0",
-  "org.scalatest"     %% "scalatest" % "3.0.1" % "test",
-  "org.pegdown"       % "pegdown"    % "1.6.0" % "test"
-)
+val play25 = "2.5.19"
+val play26 = "2.6.20"
+
+  val compileDependencies = PlayCrossCompilation.dependencies(
+    shared = Seq(
+      "uk.gov.hmrc"       %% "crypto"    % "5.4.0"
+    ),
+    play25 = Seq(
+      "com.typesafe.play" %% "play-json"        % "2.5.19",
+      "uk.gov.hmrc"       %% "http-verbs"       % "9.7.0-play-25"
+    ),
+    play26 = Seq(
+      "com.typesafe.play" %% "play-json"        % "2.6.13",
+      "uk.gov.hmrc"       %% "http-verbs"       % "9.7.0-play-26"
+    )
+  )
+
+  val testDependencies = PlayCrossCompilation.dependencies(
+    shared = Seq(
+      "org.scalatest" %% "scalatest"  % "3.0.5" % "test",
+      "org.pegdown"   % "pegdown"     % "1.6.0" % "test"
+    )
+  )
 
 lazy val library = Project(appName, file("."))
   .enablePlugins(SbtAutoBuildPlugin, SbtGitVersioning, SbtArtifactory)
   .settings(
-    libraryDependencies ++= dependencies,
+    libraryDependencies ++= compileDependencies ++ testDependencies,
     resolvers := Seq(
       Resolver.bintrayRepo("hmrc", "releases"),
       Resolver.typesafeRepo("releases")
     ),
     majorVersion := 4,
+    scalaVersion := "2.11.12",
+    crossScalaVersions := Seq("2.11.12", "2.12.8"),
     makePublicallyAvailableOnBintray := true
   )
+  .settings(PlayCrossCompilation.playCrossCompilationSettings)
   .disablePlugins(sbt.plugins.JUnitXmlReportPlugin)

--- a/project/PlayCrossCompilation.scala
+++ b/project/PlayCrossCompilation.scala
@@ -1,0 +1,4 @@
+import uk.gov.hmrc.playcrosscompilation.AbstractPlayCrossCompilation
+import uk.gov.hmrc.playcrosscompilation.PlayVersion.Play25
+
+object PlayCrossCompilation extends AbstractPlayCrossCompilation(defaultPlayVersion = Play25)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,8 +5,10 @@ resolvers += Resolver.typesafeRepo("releases")
 
 resolvers += Resolver.bintrayRepo("hmrc", "releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.13.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.16.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.15.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.19.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.14.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.19.0")
+
+addSbtPlugin("uk.gov.hmrc" % "sbt-play-cross-compilation" % "0.17.0")

--- a/src/main/scala/uk/gov/hmrc/crypto/Protected.scala
+++ b/src/main/scala/uk/gov/hmrc/crypto/Protected.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/crypto/json/JsonEncryption.scala
+++ b/src/main/scala/uk/gov/hmrc/crypto/json/JsonEncryption.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/crypto/json/JsonEncryptionSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/crypto/json/JsonEncryptionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.crypto.json
 
 import org.scalatest.{Matchers, WordSpec}
-import play.api.libs.json.{JsString, Json, Writes}
+import play.api.libs.json.{JsString, Json}
 import uk.gov.hmrc.crypto._
 
 class JsonEncryptionSpec extends WordSpec with Matchers {


### PR DESCRIPTION
Hello!

I added cross build for play 2.5-2.6 and scala 2.11-2.12.

This library is use e.g. in `http-caching-client`, so without it, upgrade to support scala 2.12 it's impossible.